### PR TITLE
Align menu close button and widen nav overlay gaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-nextjs",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 4000",

--- a/src/components/navbar/MenuOverlay.tsx
+++ b/src/components/navbar/MenuOverlay.tsx
@@ -86,9 +86,12 @@ export function MenuOverlay({
           animate={reduce ? undefined : { opacity: 1 }}
           exit={reduce ? undefined : { opacity: 0 }}
           transition={{ duration: 0.35 }}
-          className="site-container fixed inset-0 z-[60] flex flex-col overflow-hidden bg-(--overlay-bg) py-6 backdrop-blur-xl sm:py-10"
+          className="site-container fixed inset-0 z-[60] flex flex-col overflow-hidden bg-(--overlay-bg) pb-6 backdrop-blur-xl sm:pb-10"
         >
-          <div className="flex shrink-0 items-center justify-end">
+          {/* Close button sits in an h-16 row matching the nav bar exactly, so
+              it lands in the same spot as the Menu open button (no layout
+              shift / CLS between the two states). */}
+          <div className="flex h-16 shrink-0 items-center justify-end">
             <button
               ref={closeRef}
               type="button"
@@ -105,7 +108,7 @@ export function MenuOverlay({
               links + the footer stay within the screen on any device; the label
               also clamps by width (min-w-0 truncate) as a narrow-screen guard. */}
           <div className="flex min-h-0 flex-1 flex-col justify-center py-2">
-            <ul className="flex flex-col gap-[clamp(2px,0.6vh,10px)]">
+            <ul className="flex flex-col gap-[clamp(6px,1.6vh,24px)]">
               {sections.map((s, i) => (
                 <li key={s.id}>
                   <motion.span


### PR DESCRIPTION
## Changes

Two menu-overlay polish fixes reported after the Glacier rebrand.

**Close button alignment (CLS fix).** The overlay close button was
offset from the nav Menu button, so opening the menu shifted the control
under the cursor. The close button now sits in an `h-16` row matching the
nav bar's structure, so it lands in the identical box as the open button.
Verified: open and close buttons share centerY=32, centerX=1308, right=1354
at 1440px, and centerY=32 at 320px - zero layout shift.

**Wider, responsive link gaps.** The menu link rows were cramped on large
screens (~5px). Gap is now `clamp(6px, 1.6vh, 24px)` - ~14px on desktop,
~9px on mobile, capped at 24px on tall screens. The list still fits in one
view with no scroll at every viewport (verified 320x568 and 1440x900).

Version bumped 2.2.1 -> 2.2.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile navigation overlay spacing and layout.
  * Increased spacing between navigation section links.
  * Enhanced close-button row positioning for a more consistent menu experience.

* **Chores**
  * Updated the application package version to 2.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->