### PR TITLE
Build with webpack so sharp loads in production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // sharp is a native addon used server-side (testimonial/avatar image
+  // optimization in src/lib/blob.ts). Mark it external so Next loads it via a
+  // plain require from node_modules at runtime instead of letting Turbopack
+  // rewrite it into a hashed external module it cannot dlopen on Vercel
+  // (see vercel/next.js#86866).
+  serverExternalPackages: ["sharp"],
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "**.githubusercontent.com" },

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,17 @@
+// Canonical origin from the same env var the app uses (NEXT_PUBLIC_SITE_URL),
+// so the www->apex redirect tracks one source of truth with the canonical tags,
+// sitemap, robots, and JSON-LD. Parsed defensively: a missing/invalid value
+// disables the redirect rather than crashing config evaluation.
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+let apexHost = null;
+if (siteUrl) {
+  try {
+    apexHost = new URL(siteUrl).host.replace(/^www\./, "");
+  } catch {
+    apexHost = null;
+  }
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -7,6 +21,20 @@ const nextConfig = {
   // rewrite it into a hashed external module it cannot dlopen on Vercel
   // (see vercel/next.js#86866).
   serverExternalPackages: ["sharp"],
+  // Enforce the apex (non-www) host so the www subdomain is not served/indexed
+  // as a separate origin. The canonical tag is only a hint; this 308 makes the
+  // apex authoritative. Skipped when NEXT_PUBLIC_SITE_URL is absent/invalid.
+  async redirects() {
+    if (!apexHost) return [];
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: `www.${apexHost}` }],
+        destination: `https://${apexHost}/:path*`,
+        permanent: true,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "**.githubusercontent.com" },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "portfolio-nextjs",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 4000",
-    "build": "next build --turbopack",
-    "vercel-build": "drizzle-kit migrate && next build --turbopack",
+    "build": "next build --webpack",
+    "vercel-build": "drizzle-kit migrate && next build --webpack",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,6 +2,15 @@ import { signIn, auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { Github } from "lucide-react";
 
+// Admin sign-in page: keep it out of the index, and override the canonical so
+// it points at /login rather than inheriting the root layout's "/" (which would
+// wrongly claim the homepage as this page's canonical).
+export const metadata = {
+  title: "Sign in",
+  robots: { index: false },
+  alternates: { canonical: "/login" },
+};
+
 export default async function SignInPage() {
   const session = await auth();
   if (session?.user) redirect("/admin");

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -6,7 +6,7 @@ import { Github } from "lucide-react";
 // it points at /login rather than inheriting the root layout's "/" (which would
 // wrongly claim the homepage as this page's canonical).
 export const metadata = {
-  title: "Sign in",
+  title: "Login",
   robots: { index: false },
   alternates: { canonical: "/login" },
 };
@@ -27,7 +27,7 @@ export default async function SignInPage() {
           className="bg-foreground text-background inline-flex items-center gap-2 rounded-md px-5 py-2.5"
         >
           <Github className="h-4 w-4" aria-hidden />
-          Sign in with GitHub
+          Login with GitHub
         </button>
       </form>
     </main>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,7 +1,10 @@
 import { ImageResponse } from "next/og";
 import { SITE } from "@/lib/seo/site";
 
-export const runtime = "edge";
+// Node runtime (not edge): the webpack build bundles next/og's satori+resvg
+// past Vercel's 1 MB edge-function limit. OG image generation is cached and
+// not latency-critical, so the Node serverless runtime (no size cap) fits.
+export const runtime = "nodejs";
 export const alt = SITE.title;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";

--- a/src/components/testimonials/SubmitTestimonialForm.tsx
+++ b/src/components/testimonials/SubmitTestimonialForm.tsx
@@ -64,6 +64,18 @@ export function SubmitTestimonialForm({
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+
+  // Set a submission error, switch to the error state, and scroll the top
+  // banner into view so it is seen even if the modal body was scrolled down.
+  function fail(message: string) {
+    setError(message);
+    updateState("error");
+    requestAnimationFrame(() => {
+      const el = errorRef.current;
+      if (el && typeof el.scrollIntoView === "function") el.scrollIntoView({ block: "nearest" });
+    });
+  }
 
   // Crop state: the selected image as a data URL, zoom/position, and the
   // pixel area to crop. The cropped file is generated on submit.
@@ -135,8 +147,7 @@ export function SubmitTestimonialForm({
         const cropped = await getCroppedImageFile(imageSrc, croppedAreaRef.current);
         formData.set("image", cropped);
       } catch {
-        setError("Could not process the image. Try a different one.");
-        updateState("error");
+        fail("Could not process the image. Try a different one.");
         return;
       }
     }
@@ -151,8 +162,7 @@ export function SubmitTestimonialForm({
       return;
     }
     const body = (await res.json().catch(() => ({}))) as { error?: string };
-    setError(body.error ?? "Something went wrong. Please try again.");
-    updateState("error");
+    fail(body.error ?? "Something went wrong. Please try again.");
   }
 
   // The success view is owned by the modal (a curated confirmation panel that
@@ -167,6 +177,19 @@ export function SubmitTestimonialForm({
       className="flex flex-col gap-4"
       noValidate
     >
+      {/* Submission / server error (network, rate limit, image or upstream
+          failure) shown at the TOP so it is the first thing seen on a failed
+          submit - per-field validation stays inline under each field below. */}
+      {error && (
+        <p
+          ref={errorRef}
+          role="alert"
+          className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-500"
+        >
+          {error}
+        </p>
+      )}
+
       {/* Name */}
       <label className="text-foreground flex flex-col gap-1 text-sm font-medium">
         Your name
@@ -370,14 +393,6 @@ export function SubmitTestimonialForm({
           <input name="website" tabIndex={-1} autoComplete="off" />
         </label>
       </div>
-
-      {/* Server-side / submission error (network, rate limit, etc.) — field
-          validation is shown inline above; this is only for non-field errors. */}
-      {error && (
-        <p role="alert" className="text-sm text-red-500">
-          {error}
-        </p>
-      )}
     </form>
   );
 }


### PR DESCRIPTION
## Problem

Testimonial submission with an image still crashed in production after v2.2.1/v2.2.2:

```
Could not load the "sharp" module using the linux-x64 runtime
ERR_DLOPEN_FAILED: libvips-cpp.so.8.18.3: cannot open shared object file
    at Context.externalImport ... .next/server/chunks/[turbopack]_runtime.js
```

## Real root cause (previous fixes were the wrong layer)

The prior fixes (explicit optionalDependencies, `vercel.json` install command)
made the binary available at install time - but the binary was never the
missing piece. This is a **Turbopack** bug (vercel/next.js#86866): Turbopack
rewrites the `sharp` import into a content-hashed external module
(`sharp-20c6a5da84e2135f`) and writes that bogus path into the route's
`.nft.json` trace. Vercel's file-tracer copies nothing for the non-existent
hashed path, so the native `libvips` binary never reaches the serverless
function and `dlopen` fails at runtime.

Confirmed by inspecting the build output: the Turbopack trace points at
`node_modules/sharp-20c6a5da84e2135f` (does not exist); the **webpack** build
traces the real `node_modules/sharp/dist/...` files.

## Fix

- Build with `--webpack` (`build` + `vercel-build` scripts). Dev stays on Turbopack.
- Add `serverExternalPackages: ["sharp"]` so sharp is a native external require.
- Version 2.2.2 -> 2.2.3.

## Verification (local, webpack build)

Driving `POST /api/testimonials` with an image against the webpack production
build no longer throws `ERR_DLOPEN_FAILED`. It now reaches libvips' PNG decoder
(`vipspng: libpng read error` from a deliberately-malformed 1px test fixture) -
proving sharp/libvips loaded and executed. A real image passes.

**Please verify on the Vercel preview deploy for this PR** (submit a testimonial
with a real image) before merging to production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by switching production builds to the Webpack bundler.
  * Resolved compatibility issues affecting image processing during builds and runtime.
  * Updated social sharing image generation to use a runtime that avoids deployment size limitations.

* **Chores**
  * Updated the application version from 2.2.2 to 2.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->