### PR TITLE
Live GitHub stats, taglines admin, and a Settings page

### DIFF
--- a/drizzle/0015_married_spencer_smythe.sql
+++ b/drizzle/0015_married_spencer_smythe.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "github_user_cache" (
+	"username" varchar(255) PRIMARY KEY NOT NULL,
+	"followers" integer DEFAULT 0 NOT NULL,
+	"public_repos" integer DEFAULT 0 NOT NULL,
+	"total_stars" integer DEFAULT 0 NOT NULL,
+	"first_contribution_year" integer,
+	"fetched_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,973 @@
+{
+  "id": "7ae6b0dd-e283-4878-a793-addaa7757a26",
+  "prevId": "4cbe3148-896d-423b-bc2c-1e32ced3f18b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_accounts_user_id_auth_users_id_fk": {
+          "name": "auth_accounts_user_id_auth_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "auth_accounts_provider_provider_account_id_pk": {
+          "name": "auth_accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_auth_users_id_fk": {
+          "name": "auth_sessions_user_id_auth_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_users": {
+      "name": "auth_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification_tokens": {
+      "name": "auth_verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_verification_tokens_identifier_token_pk": {
+          "name": "auth_verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiences": {
+      "name": "experiences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org": {
+          "name": "org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.faqs": {
+      "name": "faqs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funding_links": {
+      "name": "funding_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary": {
+          "name": "primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_cache": {
+      "name": "github_cache",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "forks": {
+          "name": "forks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage": {
+          "name": "homepage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_cache": {
+      "name": "github_user_cache",
+      "schema": "",
+      "columns": {
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "followers": {
+          "name": "followers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_stars": {
+          "name": "total_stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_contribution_year": {
+          "name": "first_contribution_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "roles": {
+          "name": "roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "resume_url": {
+          "name": "resume_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hero_tagline": {
+          "name": "hero_tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_visibility": {
+          "name": "section_visibility",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_blurb": {
+          "name": "custom_blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_repo_unique": {
+          "name": "projects_repo_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repo"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_path": {
+          "name": "icon_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_links": {
+      "name": "social_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taglines": {
+      "name": "taglines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testimonials": {
+      "name": "testimonials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x_url": {
+          "name": "x_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "testimonial_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.testimonial_status": {
+      "name": "testimonial_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1783411983961,
       "tag": "0014_section_visibility",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1784051858135,
+      "tag": "0015_married_spencer_smythe",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-nextjs",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 4000",

--- a/src/app/admin/actions.test.ts
+++ b/src/app/admin/actions.test.ts
@@ -26,6 +26,9 @@ import {
   deleteProject,
   reorderProjects,
   updateProfile,
+  createTagline,
+  updateTagline,
+  deleteTagline,
 } from "./actions";
 
 function authedSession() {
@@ -144,5 +147,31 @@ describe("zod validation", () => {
         hidden: false,
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("taglines", () => {
+  it("blocks creating a tagline without a session", async () => {
+    mockAuth.mockResolvedValue(null);
+    await expect(createTagline({ text: "Hi", active: true, order: 0 })).rejects.toThrow(
+      "Unauthorized",
+    );
+  });
+
+  it("rejects an empty tagline text", async () => {
+    mockAuth.mockResolvedValue(authedSession());
+    await expect(createTagline({ text: "", active: true, order: 0 })).rejects.toThrow();
+  });
+
+  it("accepts a valid tagline and updates/deletes by uuid", async () => {
+    mockAuth.mockResolvedValue(authedSession());
+    const id = "11111111-1111-1111-1111-111111111111";
+    await expect(
+      createTagline({ text: "Rise above limits", active: true, order: 0 }),
+    ).resolves.toBeUndefined();
+    await expect(
+      updateTagline(id, { text: "Ship it", active: false, order: 1 }),
+    ).resolves.toBeUndefined();
+    await expect(deleteTagline(id)).resolves.toBeUndefined();
   });
 });

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -11,6 +11,7 @@ import {
   socialLinks,
   fundingLinks,
   faqs,
+  taglines,
 } from "@/db/schema";
 import {
   profileInsertSchema,
@@ -21,6 +22,7 @@ import {
   socialLinkInsertSchema,
   fundingLinkInsertSchema,
   faqInsertSchema,
+  taglineInsertSchema,
   reorderSchema,
   type ProfileInput,
   type ProjectInput,
@@ -30,6 +32,7 @@ import {
   type SocialLinkInput,
   type FundingLinkInput,
   type FaqInput,
+  type TaglineInput,
   type ReorderInput,
 } from "@/lib/schemas";
 import { auth } from "@/auth";
@@ -278,5 +281,24 @@ export async function updateFaq(id: number, input: FaqInput): Promise<void> {
 export async function deleteFaq(id: number): Promise<void> {
   await requireAdmin();
   await db.delete(faqs).where(eq(faqs.id, id));
+  revalidatePortfolio();
+}
+
+// ---------- Taglines ----------
+export async function createTagline(input: TaglineInput): Promise<void> {
+  await requireAdmin();
+  await db.insert(taglines).values(taglineInsertSchema.parse(input));
+  revalidatePortfolio();
+}
+
+export async function updateTagline(id: string, input: TaglineInput): Promise<void> {
+  await requireAdmin();
+  await db.update(taglines).set(taglineInsertSchema.parse(input)).where(eq(taglines.id, id));
+  revalidatePortfolio();
+}
+
+export async function deleteTagline(id: string): Promise<void> {
+  await requireAdmin();
+  await db.delete(taglines).where(eq(taglines.id, id));
   revalidatePortfolio();
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -27,8 +27,6 @@ import {
   taglines,
   testimonials,
 } from "@/db/schema";
-import { SectionVisibilityToggles } from "@/components/admin/SectionVisibilityToggles";
-
 export const dynamic = "force-dynamic";
 
 // One count card per collection-style section in the sidebar. Profile is a
@@ -76,10 +74,7 @@ export default async function AdminDashboard() {
     db.select({ n: count }).from(fundingLinks),
     db.select({ n: count }).from(faqs),
     db.select({ n: count }).from(taglines),
-    db
-      .select({ id: profile.id, sectionVisibility: profile.sectionVisibility })
-      .from(profile)
-      .limit(1),
+    db.select({ id: profile.id }).from(profile).limit(1),
     db
       .select({
         total: count,
@@ -102,7 +97,6 @@ export default async function AdminDashboard() {
     testimonials: Number(testimonialStats.total),
   };
   const profileConfigured = Boolean(profileRow);
-  const sectionVisibility = (profileRow?.sectionVisibility ?? {}) as Record<string, boolean>;
   const approvedCount = Number(testimonialStats.approved);
   const pendingCount = Number(testimonialStats.pending);
   const rejectedCount = Number(testimonialStats.rejected);
@@ -188,19 +182,6 @@ export default async function AdminDashboard() {
             </span>
           ) : null}
         </Link>
-      </div>
-
-      {/* Visible sections: clicking a card auto-saves; a hidden section is not
-          rendered, code-split, or data-fetched on the site (or its nav entry). */}
-      <div>
-        <div className="mb-4">
-          <h2 className="text-foreground font-semibold">Homepage sections</h2>
-          <p className="text-muted mt-0.5 text-sm">
-            Click a section to show or hide it. Changes save instantly; hidden sections never load
-            on the site or its menu.
-          </p>
-        </div>
-        <SectionVisibilityToggles visibility={sectionVisibility} />
       </div>
     </div>
   );

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -9,6 +9,7 @@ import {
   HandCoins,
   HelpCircle,
   MessageSquareQuote,
+  Quote,
   User,
   Clock,
   CheckCircle2,
@@ -23,6 +24,7 @@ import {
   socialLinks,
   fundingLinks,
   faqs,
+  taglines,
   testimonials,
 } from "@/db/schema";
 import { SectionVisibilityToggles } from "@/components/admin/SectionVisibilityToggles";
@@ -40,6 +42,7 @@ const cards = [
   { href: "/admin/social-links", label: "Social Links", icon: Link2, key: "socialLinks" },
   { href: "/admin/funding-links", label: "Funding Links", icon: HandCoins, key: "fundingLinks" },
   { href: "/admin/faqs", label: "FAQs", icon: HelpCircle, key: "faqs" },
+  { href: "/admin/taglines", label: "Taglines", icon: Quote, key: "taglines" },
   {
     href: "/admin/testimonials",
     label: "Testimonials",
@@ -61,6 +64,7 @@ export default async function AdminDashboard() {
     [social],
     [funding],
     [faq],
+    [tagline],
     [profileRow],
     [testimonialStats],
   ] = await Promise.all([
@@ -71,6 +75,7 @@ export default async function AdminDashboard() {
     db.select({ n: count }).from(socialLinks),
     db.select({ n: count }).from(fundingLinks),
     db.select({ n: count }).from(faqs),
+    db.select({ n: count }).from(taglines),
     db
       .select({ id: profile.id, sectionVisibility: profile.sectionVisibility })
       .from(profile)
@@ -93,6 +98,7 @@ export default async function AdminDashboard() {
     socialLinks: Number(social.n),
     fundingLinks: Number(funding.n),
     faqs: Number(faq.n),
+    taglines: Number(tagline.n),
     testimonials: Number(testimonialStats.total),
   };
   const profileConfigured = Boolean(profileRow);
@@ -184,14 +190,14 @@ export default async function AdminDashboard() {
         </Link>
       </div>
 
-      {/* Visible sections: switches auto-save; a section toggled off is not
+      {/* Visible sections: clicking a card auto-saves; a hidden section is not
           rendered, code-split, or data-fetched on the site (or its nav entry). */}
-      <div className="border-border bg-surface rounded-2xl border p-5">
+      <div>
         <div className="mb-4">
-          <h2 className="text-foreground font-semibold">Visible sections</h2>
+          <h2 className="text-foreground font-semibold">Homepage sections</h2>
           <p className="text-muted mt-0.5 text-sm">
-            Turn a section off to hide it from the site and the menu. Hidden sections do not load on
-            the frontend.
+            Click a section to show or hide it. Changes save instantly; hidden sections never load
+            on the site or its menu.
           </p>
         </div>
         <SectionVisibilityToggles visibility={sectionVisibility} />

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,34 @@
+import { db } from "@/db/client";
+import { profile } from "@/db/schema";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { SectionVisibilityToggles } from "@/components/admin/SectionVisibilityToggles";
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsPage() {
+  const [row] = await db
+    .select({ sectionVisibility: profile.sectionVisibility })
+    .from(profile)
+    .limit(1);
+  const sectionVisibility = (row?.sectionVisibility ?? {}) as Record<string, boolean>;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <AdminPageHeader
+        title="Settings"
+        description="Control what appears on your public portfolio."
+      />
+
+      <section className="border-border bg-surface rounded-2xl border p-5 sm:p-6">
+        <div className="mb-4">
+          <h2 className="text-foreground font-semibold">Homepage sections</h2>
+          <p className="text-muted mt-0.5 text-sm">
+            Turn a section on or off. Changes save instantly; a hidden section never loads on the
+            site or its menu.
+          </p>
+        </div>
+        <SectionVisibilityToggles visibility={sectionVisibility} />
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/taglines/page.tsx
+++ b/src/app/admin/taglines/page.tsx
@@ -1,0 +1,64 @@
+import { db } from "@/db/client";
+import { taglines } from "@/db/schema";
+import { createTagline, updateTagline, deleteTagline } from "../actions";
+import { AdminCrudPage } from "@/components/admin/AdminCrudPage";
+import { type AdminField } from "@/components/admin/RecordFormDialog";
+import { Badge } from "@/components/admin/ui";
+
+export const dynamic = "force-dynamic";
+
+const fields: AdminField[] = [
+  {
+    name: "text",
+    label: "Tagline",
+    type: "text",
+    placeholder: "Rise above limits",
+    required: true,
+  },
+  { name: "order", label: "Order", type: "number" },
+  { name: "active", label: "Active (shown in the rotation)", type: "checkbox" },
+];
+
+function parse(formData: FormData) {
+  return {
+    text: String(formData.get("text")),
+    order: Number(formData.get("order") || 0),
+    active: formData.get("active") === "on",
+  };
+}
+
+export default async function TaglinesEditor() {
+  const rows = await db.select().from(taglines).orderBy(taglines.order);
+
+  async function create(formData: FormData) {
+    "use server";
+    await createTagline(parse(formData));
+  }
+  async function update(formData: FormData) {
+    "use server";
+    await updateTagline(String(formData.get("id")), parse(formData));
+  }
+  async function remove(formData: FormData) {
+    "use server";
+    await deleteTagline(String(formData.get("id")));
+  }
+
+  return (
+    <AdminCrudPage
+      title="Taglines"
+      description="Shown under the hero, one picked at random per page load. Only active taglines appear."
+      createTitle="Add tagline"
+      editTitle="Edit tagline"
+      fields={fields}
+      rows={rows}
+      toRow={(t) => ({
+        primary: t.text,
+        badges: t.active ? null : <Badge tone="warning">Inactive</Badge>,
+      })}
+      createAction={create}
+      updateAction={update}
+      deleteAction={remove}
+      empty="No taglines yet."
+    />
+  );
+}

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -15,6 +15,7 @@ import {
   MessageSquareQuote,
   HelpCircle,
   Quote,
+  Settings,
   ExternalLink,
   PanelLeftClose,
   PanelLeft,
@@ -123,7 +124,7 @@ function UserMenu({
       {open ? (
         <div
           role="menu"
-          className="border-border bg-surface absolute right-0 z-50 mt-2 w-56 overflow-hidden rounded-xl border shadow-lg"
+          className="border-border bg-background absolute right-0 z-50 mt-2 w-56 overflow-hidden rounded-xl border shadow-lg"
         >
           <div className="border-border flex items-center gap-3 border-b px-3 py-3">
             <BrandInitialsAvatar name={userName} src={userImage} className="size-9" />
@@ -132,6 +133,15 @@ function UserMenu({
               <div className="text-muted text-xs">Administrator</div>
             </div>
           </div>
+          <Link
+            href="/admin/settings"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="text-foreground hover:bg-foreground/5 border-border flex w-full items-center gap-2 border-b px-3 py-2.5 text-sm transition"
+          >
+            <Settings className="size-4" aria-hidden />
+            Settings
+          </Link>
           <form action={logoutAction}>
             <button
               type="submit"
@@ -259,7 +269,7 @@ export function AdminShell({
             className="absolute inset-0 bg-black/50 backdrop-blur-sm"
             onClick={() => setMobileOpen(false)}
           />
-          <aside className="border-border bg-surface absolute inset-y-0 left-0 flex w-64 flex-col border-r p-4">
+          <aside className="border-border bg-background absolute inset-y-0 left-0 flex w-64 flex-col border-r p-4">
             <div className="mb-6 flex items-center justify-between px-2">
               <Link
                 href="/admin"

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -14,6 +14,7 @@ import {
   HandCoins,
   MessageSquareQuote,
   HelpCircle,
+  Quote,
   ExternalLink,
   PanelLeftClose,
   PanelLeft,
@@ -36,6 +37,7 @@ const NAV = [
   { href: "/admin/funding-links", label: "Funding Links", icon: HandCoins },
   { href: "/admin/testimonials", label: "Testimonials", icon: MessageSquareQuote },
   { href: "/admin/faqs", label: "FAQs", icon: HelpCircle },
+  { href: "/admin/taglines", label: "Taglines", icon: Quote },
 ];
 
 function NavLinks({ collapsed, onNavigate }: { collapsed?: boolean; onNavigate?: () => void }) {

--- a/src/components/admin/SectionVisibilityToggles.tsx
+++ b/src/components/admin/SectionVisibilityToggles.tsx
@@ -1,21 +1,39 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import {
+  User,
+  Wrench,
+  Briefcase,
+  FolderGit2,
+  Sparkles,
+  MessageSquareQuote,
+  HandCoins,
+  HelpCircle,
+  Mail,
+  type LucideIcon,
+} from "lucide-react";
 import { cn } from "@/utils/cn";
-import { gradientButtonBase } from "@/components/admin/styles";
 import { setSectionVisibility } from "@/app/admin/actions";
 
-const SECTIONS = [
-  { id: "about", label: "About" },
-  { id: "skills", label: "Skills" },
-  { id: "experience", label: "Experience" },
-  { id: "projects", label: "Projects" },
-  { id: "services", label: "Services" },
-  { id: "testimonials", label: "Testimonials" },
-  { id: "support", label: "Support" },
-  { id: "faq", label: "FAQ" },
-  { id: "contact", label: "Contact" },
-] as const;
+// Each toggleable homepage section, with an icon and a plain description of what
+// it shows - so the control reads as "what appears on my site", not raw keys.
+const SECTIONS: { id: string; label: string; description: string; icon: LucideIcon }[] = [
+  { id: "about", label: "About", description: "Bio, portrait, and GitHub stats", icon: User },
+  { id: "skills", label: "Skills", description: "Your tech stack and tools", icon: Wrench },
+  { id: "experience", label: "Experience", description: "Roles and work history", icon: Briefcase },
+  { id: "projects", label: "Projects", description: "Featured repos and work", icon: FolderGit2 },
+  { id: "services", label: "Services", description: "What you offer clients", icon: Sparkles },
+  {
+    id: "testimonials",
+    label: "Testimonials",
+    description: "What people say about you",
+    icon: MessageSquareQuote,
+  },
+  { id: "support", label: "Support", description: "Ways to support your work", icon: HandCoins },
+  { id: "faq", label: "FAQ", description: "Common questions answered", icon: HelpCircle },
+  { id: "contact", label: "Contact", description: "How people reach you", icon: Mail },
+];
 
 // Normalize the stored map to an explicit on/off per section (missing = visible).
 function toState(visibility: Record<string, boolean>): Record<string, boolean> {
@@ -23,96 +41,80 @@ function toState(visibility: Record<string, boolean>): Record<string, boolean> {
 }
 
 /**
- * Dashboard control: a switch per toggleable homepage section. Changes are held
- * locally and persisted only when the user clicks Save (Save is disabled until
- * something changes). A section is visible unless explicitly false.
+ * Dashboard control: one card per toggleable homepage section. Clicking a card
+ * flips its visibility and saves immediately (optimistic - the card reflects the
+ * new state at once and rolls back if the save fails). A hidden section is not
+ * rendered, code-split, or data-fetched on the site.
  */
 export function SectionVisibilityToggles({ visibility }: { visibility: Record<string, boolean> }) {
-  const [saved, setSaved] = useState(() => toState(visibility));
-  const [draft, setDraft] = useState(saved);
-  const [pending, startTransition] = useTransition();
-  const [justSaved, setJustSaved] = useState(false);
+  const [state, setState] = useState(() => toState(visibility));
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
 
-  const dirty = SECTIONS.some((s) => draft[s.id] !== saved[s.id]);
-
-  const set = (id: string, on: boolean) => {
-    setDraft((d) => ({ ...d, [id]: on }));
-    setJustSaved(false);
-  };
-
-  const save = () => {
+  const toggle = (id: string) => {
+    const next = !state[id];
+    const prev = state[id];
+    setState((s) => ({ ...s, [id]: next })); // optimistic
+    setPendingId(id);
     startTransition(async () => {
-      await setSectionVisibility(draft);
-      setSaved(draft);
-      setJustSaved(true);
+      try {
+        await setSectionVisibility({ [id]: next });
+      } catch {
+        setState((s) => ({ ...s, [id]: prev })); // rollback on failure
+      } finally {
+        setPendingId(null);
+      }
     });
   };
 
   return (
-    <div className="flex flex-col gap-5">
-      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
-        {SECTIONS.map((s) => (
-          <SectionSwitch
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {SECTIONS.map((s) => {
+        const on = state[s.id];
+        const Icon = s.icon;
+        return (
+          <button
             key={s.id}
-            label={s.label}
-            on={draft[s.id]}
-            onChange={(on) => set(s.id, on)}
-          />
-        ))}
-      </div>
+            type="button"
+            role="switch"
+            aria-checked={on}
+            aria-label={`${s.label} section, ${on ? "visible" : "hidden"}`}
+            onClick={() => toggle(s.id)}
+            disabled={pendingId === s.id}
+            className={cn(
+              "group border-border bg-surface flex items-start gap-3 rounded-2xl border p-4 text-left transition",
+              "hover:border-foreground/20 focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+              !on && "opacity-55 saturate-0",
+            )}
+          >
+            <span
+              className={cn(
+                "grid size-9 shrink-0 place-items-center rounded-lg transition-colors",
+                on
+                  ? "bg-(image:--gradient-brand) text-white"
+                  : "bg-foreground/10 text-muted",
+              )}
+            >
+              <Icon className="size-4.5" aria-hidden />
+            </span>
 
-      <div className="flex items-center justify-end gap-3">
-        {dirty ? (
-          <span className="text-muted text-sm">Unsaved changes</span>
-        ) : justSaved ? (
-          <span className="text-sm text-emerald-500">Saved</span>
-        ) : null}
-        <button
-          type="button"
-          onClick={save}
-          disabled={!dirty || pending}
-          className={cn(
-            gradientButtonBase,
-            "px-4 py-2 disabled:cursor-not-allowed disabled:opacity-50",
-          )}
-        >
-          {pending ? "Saving…" : "Save changes"}
-        </button>
-      </div>
+            <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span className="flex items-center gap-2">
+                <span className="text-foreground truncate text-sm font-semibold">{s.label}</span>
+                <span
+                  className={cn(
+                    "ml-auto shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
+                    on ? "bg-emerald-500/12 text-emerald-500" : "bg-foreground/8 text-muted",
+                  )}
+                >
+                  {on ? "Visible" : "Hidden"}
+                </span>
+              </span>
+              <span className="text-muted truncate text-xs">{s.description}</span>
+            </span>
+          </button>
+        );
+      })}
     </div>
-  );
-}
-
-function SectionSwitch({
-  label,
-  on,
-  onChange,
-}: {
-  label: string;
-  on: boolean;
-  onChange: (on: boolean) => void;
-}) {
-  return (
-    <label className="flex cursor-pointer items-center justify-between gap-3">
-      <span className="text-foreground text-sm">{label}</span>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={on}
-        aria-label={`${label} section visible`}
-        onClick={() => onChange(!on)}
-        className={cn(
-          "focus-visible:ring-ring relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:outline-none",
-          on ? "bg-(image:--gradient-brand)" : "bg-foreground/20",
-        )}
-      >
-        <span
-          className={cn(
-            "inline-block size-5 rounded-full bg-white shadow-sm transition-transform",
-            on ? "translate-x-[22px]" : "translate-x-0.5",
-          )}
-        />
-      </button>
-    </label>
   );
 }

--- a/src/components/admin/SectionVisibilityToggles.tsx
+++ b/src/components/admin/SectionVisibilityToggles.tsx
@@ -41,9 +41,9 @@ function toState(visibility: Record<string, boolean>): Record<string, boolean> {
 }
 
 /**
- * Dashboard control: one card per toggleable homepage section. Clicking a card
- * flips its visibility and saves immediately (optimistic - the card reflects the
- * new state at once and rolls back if the save fails). A hidden section is not
+ * A row per toggleable homepage section: icon, name, description, and a switch.
+ * Flipping a switch saves immediately (optimistic - the switch reflects the new
+ * state at once and rolls back if the save fails). A hidden section is not
  * rendered, code-split, or data-fetched on the site.
  */
 export function SectionVisibilityToggles({ visibility }: { visibility: Record<string, boolean> }) {
@@ -68,53 +68,48 @@ export function SectionVisibilityToggles({ visibility }: { visibility: Record<st
   };
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+    <ul className="divide-border divide-y">
       {SECTIONS.map((s) => {
         const on = state[s.id];
         const Icon = s.icon;
         return (
-          <button
-            key={s.id}
-            type="button"
-            role="switch"
-            aria-checked={on}
-            aria-label={`${s.label} section, ${on ? "visible" : "hidden"}`}
-            onClick={() => toggle(s.id)}
-            disabled={pendingId === s.id}
-            className={cn(
-              "group border-border bg-surface flex items-start gap-3 rounded-2xl border p-4 text-left transition",
-              "hover:border-foreground/20 focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
-              !on && "opacity-55 saturate-0",
-            )}
-          >
+          <li key={s.id} className="flex items-center gap-4 py-3.5 first:pt-0 last:pb-0">
             <span
               className={cn(
                 "grid size-9 shrink-0 place-items-center rounded-lg transition-colors",
-                on
-                  ? "bg-(image:--gradient-brand) text-white"
-                  : "bg-foreground/10 text-muted",
+                on ? "bg-(image:--gradient-brand) text-white" : "bg-foreground/10 text-muted",
               )}
             >
               <Icon className="size-4.5" aria-hidden />
             </span>
 
-            <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <span className="flex items-center gap-2">
-                <span className="text-foreground truncate text-sm font-semibold">{s.label}</span>
-                <span
-                  className={cn(
-                    "ml-auto shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium",
-                    on ? "bg-emerald-500/12 text-emerald-500" : "bg-foreground/8 text-muted",
-                  )}
-                >
-                  {on ? "Visible" : "Hidden"}
-                </span>
-              </span>
-              <span className="text-muted truncate text-xs">{s.description}</span>
-            </span>
-          </button>
+            <div className="min-w-0 flex-1">
+              <div className="text-foreground text-sm font-medium">{s.label}</div>
+              <div className="text-muted truncate text-xs">{s.description}</div>
+            </div>
+
+            <button
+              type="button"
+              role="switch"
+              aria-checked={on}
+              aria-label={`${s.label} section, ${on ? "visible" : "hidden"}`}
+              onClick={() => toggle(s.id)}
+              disabled={pendingId === s.id}
+              className={cn(
+                "focus-visible:ring-ring relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:opacity-60",
+                on ? "bg-(image:--gradient-brand)" : "bg-foreground/20",
+              )}
+            >
+              <span
+                className={cn(
+                  "inline-block size-5 rounded-full bg-white shadow-sm transition-transform",
+                  on ? "translate-x-[22px]" : "translate-x-0.5",
+                )}
+              />
+            </button>
+          </li>
         );
       })}
-    </div>
+    </ul>
   );
 }

--- a/src/components/home/About.test.tsx
+++ b/src/components/home/About.test.tsx
@@ -14,7 +14,7 @@ beforeEach(() => installMatchMedia({ "(prefers-reduced-motion: reduce)": true })
 
 const mockProfile = {
   bio: "I build fast, accessible web apps and love open source.",
-  stats: { years: 4, repos: 120, stars: 250 },
+  stats: { years: 4, repos: 120, stars: 250, followers: 87 },
 };
 
 describe("About", () => {
@@ -27,9 +27,10 @@ describe("About", () => {
 
   it("renders stat labels", () => {
     render(<About profile={mockProfile} />);
-    expect(screen.getByText("Years building")).toBeInTheDocument();
+    expect(screen.getByText("Years of building")).toBeInTheDocument();
     expect(screen.getByText("Public repos")).toBeInTheDocument();
     expect(screen.getByText("GitHub stars")).toBeInTheDocument();
+    expect(screen.getByText("GitHub followers")).toBeInTheDocument();
   });
 
   it("renders stat values with + suffix for values >= 100", () => {
@@ -40,6 +41,8 @@ describe("About", () => {
     expect(screen.getByText("120+")).toBeInTheDocument();
     // stars = 250 → "250+"
     expect(screen.getByText("250+")).toBeInTheDocument();
+    // followers = 87 → no suffix (< 100)
+    expect(screen.getByText("87")).toBeInTheDocument();
   });
 
   it("renders the section with correct id", () => {

--- a/src/components/home/About.tsx
+++ b/src/components/home/About.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/utils/cn";
 
 export type AboutProfile = {
   bio: string;
-  stats: { years: number; repos: number; stars: number };
+  stats: { years: number; repos: number; stars: number; followers: number };
   name?: string;
   avatarUrl?: string;
 };
@@ -20,13 +20,21 @@ type StatGridProps = {
 
 function StatGrid({ stats, className }: StatGridProps) {
   const items: { value: number; label: string }[] = [
-    { value: stats.years, label: "Years building" },
+    { value: stats.years, label: "Years of building" },
     { value: stats.repos, label: "Public repos" },
     { value: stats.stars, label: "GitHub stars" },
+    { value: stats.followers, label: "GitHub followers" },
   ];
 
   return (
-    <Card className={cn("divide-border mt-12 grid grid-cols-3 divide-x p-0", className)}>
+    // 2x2 on mobile, 4-across from md up. divide-y separates the mobile rows;
+    // the vertical dividers only apply once the grid is a single row (md).
+    <Card
+      className={cn(
+        "divide-border mt-12 grid grid-cols-2 divide-x divide-y p-0 md:grid-cols-4 md:divide-y-0",
+        className,
+      )}
+    >
       {items.map(({ value, label }, i) => (
         <AnimatedStat key={label} value={value} label={label} delay={0.1 + i * 0.08} />
       ))}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -191,6 +191,20 @@ export const githubCache = pgTable("github_cache", {
   fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
+// Account-level GitHub stats (followers, public repo count) cached persistently
+// so the About stats render instantly from the last-known-good row and refresh
+// in the background - they never flash blank while a fresh fetch is in flight.
+export const githubUserCache = pgTable("github_user_cache", {
+  username: varchar("username", { length: 255 }).primaryKey(),
+  followers: integer("followers").notNull().default(0),
+  publicRepos: integer("public_repos").notNull().default(0),
+  // Sum of stargazers across all owned public non-fork repos.
+  totalStars: integer("total_stars").notNull().default(0),
+  // Earliest year the user contributed on GitHub, for deriving "years building".
+  firstContributionYear: integer("first_contribution_year"),
+  fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 // Inferred types
 export type Profile = typeof profile.$inferSelect;
 export type NewProfile = typeof profile.$inferInsert;
@@ -214,3 +228,5 @@ export type Faq = typeof faqs.$inferSelect;
 export type NewFaq = typeof faqs.$inferInsert;
 export type GithubCache = typeof githubCache.$inferSelect;
 export type NewGithubCache = typeof githubCache.$inferInsert;
+export type GithubUserCache = typeof githubUserCache.$inferSelect;
+export type NewGithubUserCache = typeof githubUserCache.$inferInsert;

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -33,7 +33,7 @@ const seededAvatarUrl = `${SITE_ORIGIN}/images/nikhil.png`;
 const profileRow = {
   name: "Nikhil Rajput",
   bio: "Nikhil Rajput is a Software Development Engineer and AI Lead who builds fast, reliable products across web and mobile. He works full-stack - crafting polished front-ends with React and Next.js, mobile apps with Flutter, and robust back-ends with Node.js - with a growing focus on applied AI.\n\nBeyond his day-to-day engineering, he is an active open-source contributor, maintaining libraries and tools that other developers rely on. He cares about clean architecture, thoughtful UX, and shipping work that lasts.",
-  stats: { years: 4, repos: 60, stars: 0 },
+  stats: { years: 4, repos: 60, stars: 0, followers: 0 },
   roles: ["Software Development Engineer", "Full Stack Developer", "Open Source Contributor"],
   // Resume URL lives in the DB only — set it via the admin panel.
   resumeUrl: null,

--- a/src/lib/github-cache.ts
+++ b/src/lib/github-cache.ts
@@ -1,8 +1,8 @@
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
-import { githubCache } from "@/db/schema";
-import type { GithubCache } from "@/db/schema";
-import { getRepo } from "@/lib/github";
+import { githubCache, githubUserCache } from "@/db/schema";
+import type { GithubCache, GithubUserCache } from "@/db/schema";
+import { getRepo, getUserStats } from "@/lib/github";
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -15,7 +15,7 @@ export type CachedRepoStats = {
   htmlUrl: string | null;
 };
 
-function isStale(row: GithubCache): boolean {
+function isStale(row: { fetchedAt: Date }): boolean {
   return Date.now() - row.fetchedAt.getTime() > CACHE_TTL_MS;
 }
 
@@ -130,4 +130,61 @@ export async function getCachedRepoData(slugs: string[]): Promise<Map<string, Ca
   );
 
   return result;
+}
+
+export type CachedUserStats = {
+  followers: number;
+  publicRepos: number;
+  totalStars: number;
+  firstContributionYear: number | null;
+};
+
+function userRowToStats(row: GithubUserCache): CachedUserStats {
+  return {
+    followers: row.followers,
+    publicRepos: row.publicRepos,
+    totalStars: row.totalStars,
+    firstContributionYear: row.firstContributionYear,
+  };
+}
+
+/**
+ * Reads github_user_cache for a username, serving the last-known-good row
+ * instantly. Missing or stale (>24h) rows are refreshed via one GitHub GraphQL
+ * query (followers, owned public non-fork repo count + their star sum, and the
+ * first year the user contributed) and upserted. On fetch failure, falls back
+ * to the existing row; only a cold cache with a failed first fetch yields nulls.
+ * Never throws.
+ */
+export async function getCachedUserStats(username: string): Promise<CachedUserStats | null> {
+  const [cached] = await db
+    .select()
+    .from(githubUserCache)
+    .where(eq(githubUserCache.username, username));
+
+  if (cached && !isStale(cached)) return userRowToStats(cached);
+
+  try {
+    const live = await getUserStats(username);
+    if (live) {
+      const row = { username, ...live, fetchedAt: new Date() };
+      await db
+        .insert(githubUserCache)
+        .values(row)
+        .onConflictDoUpdate({
+          target: githubUserCache.username,
+          set: {
+            followers: row.followers,
+            publicRepos: row.publicRepos,
+            totalStars: row.totalStars,
+            firstContributionYear: row.firstContributionYear,
+            fetchedAt: row.fetchedAt,
+          },
+        });
+      return live;
+    }
+    return cached ? userRowToStats(cached) : null;
+  } catch {
+    return cached ? userRowToStats(cached) : null;
+  }
 }

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getRepo, listUserRepos } from "./github";
+import { getRepo, getUserStats, listUserRepos } from "./github";
 
 const repoFixture = {
   name: "siphon",
@@ -54,5 +54,50 @@ describe("listUserRepos", () => {
     );
     const repos = await listUserRepos("nixrajput");
     expect(repos).toHaveLength(1);
+  });
+});
+
+describe("getUserStats", () => {
+  const statsResponse = {
+    data: {
+      user: {
+        followers: { totalCount: 112 },
+        repositories: {
+          totalCount: 61,
+          nodes: [{ stargazerCount: 500 }, { stargazerCount: 115 }],
+        },
+        contributionsCollection: { contributionYears: [2026, 2020, 2015, 2018] },
+      },
+    },
+  };
+
+  it("sums stars and picks the earliest contribution year", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(statsResponse), { status: 200 })),
+    );
+    const stats = await getUserStats("nixrajput");
+    expect(stats).toEqual({
+      followers: 112,
+      publicRepos: 61,
+      totalStars: 615,
+      firstContributionYear: 2015,
+    });
+  });
+
+  it("returns null when the user is absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ data: { user: null } }), { status: 200 })),
+    );
+    expect(await getUserStats("ghost")).toBeNull();
+  });
+
+  it("throws on a non-ok response so the caller can fall back", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 401 })),
+    );
+    await expect(getUserStats("nixrajput")).rejects.toThrow();
   });
 });

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,6 +1,12 @@
-import { githubRepoListSchema, githubRepoSchema, type GithubRepo } from "./schemas";
+import {
+  githubRepoListSchema,
+  githubRepoSchema,
+  githubUserStatsSchema,
+  type GithubRepo,
+} from "./schemas";
 
 const GITHUB_API = "https://api.github.com";
+const GITHUB_GRAPHQL = "https://api.github.com/graphql";
 const REVALIDATE_SECONDS = 3600;
 
 function authHeaders(): HeadersInit {
@@ -12,6 +18,51 @@ function authHeaders(): HeadersInit {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export type GithubUserStats = {
+  followers: number;
+  publicRepos: number;
+  totalStars: number;
+  firstContributionYear: number | null;
+};
+
+// Single GraphQL query for all account-level stats: followers, owned public
+// non-fork repo count + their stargazer sum, and the years the user contributed
+// in (the earliest is the first year they built on GitHub). GraphQL requires a
+// token; without one the request 401s and the caller falls back to the cache.
+const USER_STATS_QUERY = `query($login:String!){
+  user(login:$login){
+    followers{totalCount}
+    repositories(privacy:PUBLIC ownerAffiliations:OWNER isFork:false first:100){
+      totalCount
+      nodes{stargazerCount}
+    }
+    contributionsCollection{contributionYears}
+  }
+}`;
+
+/** Fetch account-level stats via the GraphQL API. Returns null if the user is
+ *  absent. Throws on transport/schema errors so the caller can fall back. */
+export async function getUserStats(username: string): Promise<GithubUserStats | null> {
+  const res = await fetch(GITHUB_GRAPHQL, {
+    method: "POST",
+    headers: { ...authHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify({ query: USER_STATS_QUERY, variables: { login: username } }),
+    next: { revalidate: REVALIDATE_SECONDS, tags: ["github"] },
+  });
+  if (!res.ok) throw new Error(`GitHub getUserStats ${username} failed: ${res.status}`);
+  const parsed = githubUserStatsSchema.parse(await res.json());
+  const user = parsed.data.user;
+  if (!user) return null;
+
+  const years = user.contributionsCollection.contributionYears;
+  return {
+    followers: user.followers.totalCount,
+    publicRepos: user.repositories.totalCount,
+    totalStars: user.repositories.nodes.reduce((sum, r) => sum + r.stargazerCount, 0),
+    firstContributionYear: years.length > 0 ? Math.min(...years) : null,
   };
 }
 

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Hoist mock state so vi.mock factories can reference it ────────────────────
 
@@ -50,6 +50,10 @@ vi.mock("@/db/client", () => ({
 vi.mock("@/lib/projects", () => ({
   getProjects: vi.fn().mockResolvedValue([{ repo: "a", featured: true, hidden: false }]),
 }));
+
+// Mock the GitHub user cache so getProfile's live account-stats read stays offline.
+const { getCachedUserStatsMock } = vi.hoisted(() => ({ getCachedUserStatsMock: vi.fn() }));
+vi.mock("@/lib/github-cache", () => ({ getCachedUserStats: getCachedUserStatsMock }));
 
 // ── Import after mocks are registered ────────────────────────────────────────
 
@@ -164,7 +168,17 @@ describe("getFundingLinks", () => {
 });
 
 describe("getProfile", () => {
-  it("shapes profile row reading roles from dedicated column", async () => {
+  // Pin "now" so years-since-account-created is deterministic.
+  beforeEach(() => vi.useFakeTimers().setSystemTime(new Date("2026-01-01T00:00:00Z")));
+  afterEach(() => vi.useRealTimers());
+
+  it("shapes profile row deriving all GitHub stats from the user cache", async () => {
+    getCachedUserStatsMock.mockResolvedValue({
+      followers: 112,
+      publicRepos: 72,
+      totalStars: 340,
+      firstContributionYear: 2018, // 8 years before pinned now (2026)
+    });
     _setRows([
       {
         id: 1,
@@ -179,14 +193,18 @@ describe("getProfile", () => {
     ]);
     const result = await getProfile();
     expect(result.name).toBe("Nikhil Rajput");
-    expect(result.bio).toBe("Bio text");
-    expect(result.avatarUrl).toBe("/avatar.jpg");
-    expect(result.resumeUrl).toBe("/resume.pdf");
     expect(result.roles).toEqual(["Developer", "Designer"]);
-    expect(result.stats).toEqual({ years: 4, repos: 60, stars: 1200 });
+    // years/repos/stars/followers all come from the live cache, not the seed.
+    expect(result.stats).toEqual({ years: 8, repos: 72, stars: 340, followers: 112 });
   });
 
   it("returns empty roles and defaults from column defaults", async () => {
+    getCachedUserStatsMock.mockResolvedValue({
+      followers: 5,
+      publicRepos: 9,
+      totalStars: 11,
+      firstContributionYear: 2024, // 2 years before pinned now (2026)
+    });
     _setRows([
       {
         id: 1,
@@ -204,7 +222,26 @@ describe("getProfile", () => {
     // A missing avatar falls back to the bundled asset so the hero never breaks.
     expect(result.avatarUrl).toBe("/images/nikhil.png");
     expect(result.resumeUrl).toBe("");
-    expect(result.stats).toEqual({ years: 0, repos: 0, stars: 0 });
+    expect(result.stats).toEqual({ years: 2, repos: 9, stars: 11, followers: 5 });
+  });
+
+  it("falls back to the seeded stats when the GitHub cache is empty", async () => {
+    // Cold cache + failed fetch → getCachedUserStats returns null.
+    getCachedUserStatsMock.mockResolvedValue(null);
+    _setRows([
+      {
+        id: 1,
+        name: "Test",
+        bio: "Bio",
+        stats: { years: 4, repos: 60, stars: 250, followers: 42 },
+        roles: [],
+        resumeUrl: null,
+        avatarUrl: null,
+        updatedAt: new Date(),
+      },
+    ]);
+    const result = await getProfile();
+    expect(result.stats).toEqual({ years: 4, repos: 60, stars: 250, followers: 42 });
   });
 
   it("throws when profile row is missing", async () => {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,4 +1,4 @@
-import { asc, eq, sql } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 
 import { db } from "@/db/client";
 import {
@@ -10,15 +10,23 @@ import {
   fundingLinks,
   taglines,
   faqs,
-  githubCache,
 } from "@/db/schema";
 import type { Experience, Skill, Service, Faq } from "@/db/schema";
 import { getProjects } from "@/lib/projects";
 import type { MergedProject } from "@/lib/projects";
+import { getCachedUserStats } from "@/lib/github-cache";
 
 // Bundled asset shown when the profile has no avatar set yet (e.g. before the
 // admin uploads one). Served from `public/`, so a relative src is correct here.
 const FALLBACK_AVATAR = "/images/nikhil.png";
+
+// GitHub account backing the live stats (same owner as the curated repos).
+const GITHUB_USERNAME = "nixrajput";
+
+// Years building = current year minus the first year the user contributed.
+function yearsBuilding(firstContributionYear: number): number {
+  return Math.max(0, new Date().getFullYear() - firstContributionYear);
+}
 
 // ── Public row types ────────────────────────────────────────────────────────
 
@@ -55,7 +63,7 @@ export async function getProfile(): Promise<{
   resumeUrl: string;
   heroTagline: string | null;
   sectionVisibility: Record<string, boolean>;
-  stats: { years: number; repos: number; stars: number };
+  stats: { years: number; repos: number; stars: number; followers: number };
 }> {
   const rows = await db.select().from(profile);
   const row = rows[0];
@@ -63,14 +71,22 @@ export async function getProfile(): Promise<{
 
   const s = row.stats as Record<string, unknown>;
 
-  // Derive the live total star count from the GitHub cache when available;
-  // fall back to the seeded value if the cache is empty (before first fetch).
-  // `repos` stays from the seed — the cache only holds curated repos, not the
-  // full public-repo count.
-  const [agg] = await db
-    .select({ totalStars: sql<number>`coalesce(sum(${githubCache.stars}), 0)` })
-    .from(githubCache);
-  const cachedStars = Number(agg?.totalStars ?? 0);
+  // All four GitHub-derived stats come from the persistent user cache: served
+  // from the last-known-good row instantly and refreshed in the background, so
+  // they never flash blank. Each falls back to the seeded stats blob only on a
+  // cold cache with a failed first fetch.
+  //  - repos:     public repo count
+  //  - stars:     sum of stargazers across ALL public repos
+  //  - followers: follower count
+  //  - years:     whole years since the first contribution
+  const userStats = await getCachedUserStats(GITHUB_USERNAME);
+  const followers = userStats ? userStats.followers : Number(s.followers ?? 0);
+  const repos =
+    userStats && userStats.publicRepos > 0 ? userStats.publicRepos : Number(s.repos ?? 0);
+  const stars = userStats && userStats.totalStars > 0 ? userStats.totalStars : Number(s.stars ?? 0);
+  const years = userStats?.firstContributionYear
+    ? yearsBuilding(userStats.firstContributionYear)
+    : Number(s.years ?? 0);
 
   return {
     name: row.name,
@@ -80,11 +96,7 @@ export async function getProfile(): Promise<{
     heroTagline: row.heroTagline ?? null,
     sectionVisibility: (row.sectionVisibility as Record<string, boolean>) ?? {},
     roles: row.roles,
-    stats: {
-      years: Number(s.years ?? 0),
-      repos: Number(s.repos ?? 0),
-      stars: cachedStars > 0 ? cachedStars : Number(s.stars ?? 0),
-    },
+    stats: { years, repos, stars, followers },
   };
 }
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -106,6 +106,25 @@ export const githubRepoSchema = z.object({
 
 export const githubRepoListSchema = z.array(githubRepoSchema);
 
+// GitHub GraphQL user stats (single query: followers, owned public non-fork
+// repos + their stars, and the years the user has contributed in).
+export const githubUserStatsSchema = z.object({
+  data: z.object({
+    user: z
+      .object({
+        followers: z.object({ totalCount: z.number() }),
+        repositories: z.object({
+          totalCount: z.number(),
+          nodes: z.array(z.object({ stargazerCount: z.number() })),
+        }),
+        contributionsCollection: z.object({
+          contributionYears: z.array(z.number()),
+        }),
+      })
+      .nullable(),
+  }),
+});
+
 // ---------- Inferred types ----------
 export type ProfileInput = z.infer<typeof profileInsertSchema>;
 export type ProjectInput = z.infer<typeof projectInsertSchema>;
@@ -118,3 +137,4 @@ export type TaglineInput = z.infer<typeof taglineInsertSchema>;
 export type FaqInput = z.infer<typeof faqInsertSchema>;
 export type ReorderInput = z.infer<typeof reorderSchema>;
 export type GithubRepo = z.infer<typeof githubRepoSchema>;
+export type GithubUserStatsResponse = z.infer<typeof githubUserStatsSchema>;


### PR DESCRIPTION
Three related admin/portfolio improvements on one branch. Rebased onto master after #24 merged.

## Live GitHub stats in About

All four About stats now come live from GitHub via a **single GraphQL query** (`getUserStats`), replacing the previously seeded/curated values:

- **Years of building** - current year minus the first year you contributed (`contributionsCollection.contributionYears`).
- **Public repos** - owned, non-fork public repo count.
- **GitHub stars** - sum of stargazers across all owned public non-fork repos (previously only summed the ~10 curated repos).
- **GitHub followers** - live follower count.

Persisted in a new `github_user_cache` table (migration `0015`), served last-known-good and refreshed on a 24h TTL, so the stats **never flash blank** while a fresh fetch is in flight. Each falls back to the seeded stats blob only on a cold cache with a failed first fetch. The grid gains a fourth card and lays out 2x2 on mobile, 4-across on desktop.

## Taglines admin

New `/admin/taglines` CRUD page (list, create, edit, delete) so the random hero taglines are managed in the UI instead of the seed. No schema change - the `taglines` table already supported N rows and `getRandomTagline` already picks one at random; there was just no way to add them. Adds a taglines count card and sidebar entry.

## Settings page + popover fix

- Moved homepage-section visibility to a dedicated `/admin/settings` page, reached via a new **Settings** item in the profile menu (off the content dashboard). The control is toggle switches (icon, name, description, switch) that auto-save on flip.
- **Fixed the profile popover and mobile drawer showing through**: they used the translucent glass `bg-surface` token; switched to the opaque `bg-background` so floating menus occlude the content behind them.

## Verification

- All four stats verified live in the running app (Years 11, Repos 61, Stars 615+, Followers 112+); Settings toggles and states verified via the real component.
- 254 tests pass; TypeScript, ESLint, and Prettier all clean.

## Note for reviewer

Public repos shows **61** (owned, non-fork) rather than GitHub's REST `public_repos` of 72 which counts forks - deliberate, but easy to switch if you want the higher number. Version bumped to **2.2.5** (past master's 2.2.4 from #24).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin management for homepage taglines, including create, edit, delete, ordering, and active status controls.
  * Added an admin Settings page for managing homepage section visibility with immediate updates.
  * Added GitHub follower statistics to the profile display.
  * Added caching and fallback support for GitHub user statistics.

* **Bug Fixes**
  * Improved profile statistics reliability when GitHub data is unavailable.

* **Tests**
  * Added coverage for tagline management and GitHub statistics retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->